### PR TITLE
dbusClient: sync access to dbus object references

### DIFF
--- a/iot.agile.http/src/main/java/iot/agile/http/service/DbusClient.java
+++ b/iot.agile.http/src/main/java/iot/agile/http/service/DbusClient.java
@@ -54,7 +54,7 @@ public class DbusClient {
     connection = DBusConnection.getConnection(AgileObjectInterface.DEFAULT_DBUS_CONNECTION);
   }
 
-  protected DBusInterface getObject(String objectBusname, String objectPath, Class<? extends DBusInterface> clazz) throws DBusException {
+  protected synchronized DBusInterface getObject(String objectBusname, String objectPath, Class<? extends DBusInterface> clazz) throws DBusException {
     
     String key = objectBusname + ":" + objectPath;
     if(instances.containsKey(key)) {


### PR DESCRIPTION
Fix concurrency issues with DBus access with dbus-java.

Seems to fix https://github.com/Agile-IoT/agile-core/issues/56