### PR TITLE
Persistence Fix

### DIFF
--- a/org.eclipse.agail.DeviceManager/src/main/java/org/eclipse/agail/devicemanager/jsondb/JsonDB.java
+++ b/org.eclipse.agail.DeviceManager/src/main/java/org/eclipse/agail/devicemanager/jsondb/JsonDB.java
@@ -28,8 +28,12 @@ public class JsonDB {
 	private File dbFile;
 
 	private void setFile() {
-		if (System.getenv("DBFILE") != null && dbFile == null) {
+		logger.debug("System.getenv(\"DBFILE\") {}", System.getenv("DBFILE"));
+		if(System.getenv("DBFILE") != null) {
 			dbFileName = System.getenv("DBFILE");
+		}
+		logger.debug("DBdevice File found {}", dbFileName);
+		if (dbFile == null) {
 			dbFile = new File(dbFileName);
 			if (dbFile.exists()) {
 				logger.info("DB File {} found.", dbFileName);


### PR DESCRIPTION
If DBFILE variable not available in docker-compose then it will create a new file, else it will read env variable for the db file and start saving data in that file.

Change-type: patch
Signed-off-by: Ans Riaz <ansriazch@gmail.com>